### PR TITLE
[Feature] Add reusable multi-program prepared processes

### DIFF
--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -110,7 +110,7 @@ async function initializeWasm() {
     logger.warn("initializeWasm is deprecated, you no longer need to use it");
 }
 
-export { ProgramManager, PreparedProgram, PrepareProgramOptions, ProvingRequestOptions, ExecuteOptions, FeeAuthorizationOptions, AuthorizationOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof, programChecksum } from "./program-manager.js";
+export { ProgramManager, PreparedProgram, PreparedProcess, PrepareProgramOptions, ProgramPreparationOptions, PrepareProcessOptions, PreparedProcessProgram, PreparedProcessSupportsOptions, ProvingRequestOptions, ExecuteOptions, FeeAuthorizationOptions, AuthorizationOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof, programChecksum } from "./program-manager.js";
 
 export { logAndThrow, TransportFunction, defaultTransport, cookieAffinityTransport } from "./utils/utils.js";
 

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -198,7 +198,7 @@ interface PreparedCallContext {
 const preparedContextBuilders = new WeakMap<object, ProgramImportsBuilder>();
 const preparedProcessPrograms = new WeakMap<object, Map<string, PreparedProcessProgram>>();
 const preparedProgramImports = new WeakMap<object, Map<string, string>>();
-const preparedContextQueues = new WeakMap<object, Promise<unknown>>();
+const preparedContextQueues = new WeakMap<object, Promise<void>>();
 
 function normalizeProgramSource(program: string | Program): string {
     return program instanceof Program ? program.toString() : program;
@@ -270,8 +270,13 @@ function withPreparedContextWasm<T>(
     const previous = preparedContextQueues.get(preparedContext) ?? Promise.resolve();
     const next = previous.then(call, call);
     // Keep the queue alive regardless of how this call settles so one failure
-    // does not block later calls on the same context.
-    preparedContextQueues.set(preparedContext, next.catch(() => undefined));
+    // does not block later calls on the same context. Normalize both outcomes
+    // so the queue does not retain a successful WASM result.
+    const tail = next.then(
+        () => undefined,
+        () => undefined,
+    );
+    preparedContextQueues.set(preparedContext, tail);
     return next;
 }
 
@@ -2312,7 +2317,7 @@ class ProgramManager {
             ? clonePreparedContextBuilder(preparedCall.context)
             : (await this.buildProgramImports(program, imports, false, functionName)).builder;
         const hasPreparedContext = preparedCall !== undefined;
-        const hasImports = !builder.isEmpty();
+        const hasImports = !hasPreparedContext && !builder.isEmpty();
 
         // Build and return an `Authorization` for the desired function.
         const authorization = await withPreparedContextWasm(preparedCall?.context, () =>
@@ -2421,7 +2426,7 @@ class ProgramManager {
             ? clonePreparedContextBuilder(preparedCall.context)
             : (await this.buildProgramImports(program, imports, false, functionName)).builder;
         const hasPreparedContext = preparedCall !== undefined;
-        const hasImports = !builder.isEmpty();
+        const hasImports = !hasPreparedContext && !builder.isEmpty();
 
         // Build and return an `Authorization` for the desired function.
         const authorization = await withPreparedContextWasm(preparedCall?.context, () =>
@@ -2553,7 +2558,7 @@ class ProgramManager {
             ? clonePreparedContextBuilder(preparedCall.context)
             : (await this.buildProgramImports(program, imports, false, functionName)).builder;
         const hasPreparedContext = preparedCall !== undefined;
-        const hasImports = !builder.isEmpty();
+        const hasImports = !hasPreparedContext && !builder.isEmpty();
         const hasProcessBuilder = hasPreparedContext || hasImports;
 
         // Get the fee record from the account if it is not provided in the parameters

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -199,9 +199,21 @@ const preparedContextBuilders = new WeakMap<object, ProgramImportsBuilder>();
 const preparedProcessPrograms = new WeakMap<object, Map<string, PreparedProcessProgram>>();
 const preparedProgramImports = new WeakMap<object, Map<string, string>>();
 const preparedContextQueues = new WeakMap<object, Promise<void>>();
+const CREDITS_PROGRAM_ID = "credits.aleo";
 
 function normalizeProgramSource(program: string | Program): string {
     return program instanceof Program ? program.toString() : program;
+}
+
+function preparedProcessHasCompatibleImport(
+    programs: Map<string, PreparedProcessProgram>,
+    name: string,
+    source: string | Program,
+): boolean {
+    // Every snarkVM process already contains credits.aleo, and the imports
+    // builder intentionally does not retain that built-in in its metadata.
+    return name === CREDITS_PROGRAM_ID
+        || programs.get(name)?.programSource === normalizeProgramSource(source);
 }
 
 function preparedProcessSupports(
@@ -231,7 +243,7 @@ function preparedProcessSupports(
     }
     if (options.programImports) {
         for (const [name, source] of Object.entries(options.programImports)) {
-            if (programs.get(name)?.programSource !== normalizeProgramSource(source)) {
+            if (!preparedProcessHasCompatibleImport(programs, name, source)) {
                 return false;
             }
         }
@@ -866,7 +878,7 @@ class ProgramManager {
 
         for (const [name, imports] of staticImports) {
             for (const importedName of imports) {
-                if (importedName !== "credits.aleo" && !sources.has(importedName)) {
+                if (importedName !== CREDITS_PROGRAM_ID && !sources.has(importedName)) {
                     throw new Error(`Missing import '${importedName}' required by program '${name}'`);
                 }
             }
@@ -1006,7 +1018,7 @@ class ProgramManager {
         }
         if (options.programImports) {
             for (const [name, source] of Object.entries(options.programImports)) {
-                if (programs.get(name)?.programSource !== normalizeProgramSource(source)) {
+                if (!preparedProcessHasCompatibleImport(programs, name, source)) {
                     throw new Error(
                         `Prepared process import '${name}' does not match a loaded program`,
                     );

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -197,7 +197,8 @@ interface PreparedCallContext {
 
 const preparedContextBuilders = new WeakMap<object, ProgramImportsBuilder>();
 const preparedProcessPrograms = new WeakMap<object, Map<string, PreparedProcessProgram>>();
-const busyPreparedContexts = new WeakSet<object>();
+const preparedProgramImports = new WeakMap<object, Map<string, string>>();
+const preparedContextQueues = new WeakMap<object, Promise<unknown>>();
 
 function normalizeProgramSource(program: string | Program): string {
     return program instanceof Program ? program.toString() : program;
@@ -249,28 +250,29 @@ function selectedPreparedContext(options: {
 }
 
 /**
- * Run an action while holding exclusive use of a prepared context.
+ * Serialize WASM calls that borrow a prepared context's snarkVM process.
  *
  * WASM builder clones are reference-counted handles to one mutable snarkVM
- * process. Concurrent calls would otherwise cause a RefCell borrow panic and
- * abort the WASM module, so reject them with a catchable error instead.
+ * process guarded by a RefCell. Overlapping borrows would panic and abort the
+ * WASM module, so calls sharing a context are queued behind one another at the
+ * WASM boundary. Only the WASM call itself is queued: network resolution and
+ * fee record lookup still run concurrently across calls.
+ *
+ * The entry points that accept a prepared context currently complete their
+ * borrow without yielding, so the queue never waits in practice. It exists to
+ * turn a future borrow-across-await into a delayed call rather than a panic.
  */
-async function withPreparedContext<T>(
+function withPreparedContextWasm<T>(
     preparedContext: PreparedContext | undefined,
-    action: () => Promise<T>,
+    call: () => Promise<T>,
 ): Promise<T> {
-    if (!preparedContext) return action();
-    if (busyPreparedContexts.has(preparedContext)) {
-        throw new Error(
-            "Prepared context is already in use; calls sharing a prepared context must be sequential",
-        );
-    }
-    busyPreparedContexts.add(preparedContext);
-    try {
-        return await action();
-    } finally {
-        busyPreparedContexts.delete(preparedContext);
-    }
+    if (!preparedContext) return call();
+    const previous = preparedContextQueues.get(preparedContext) ?? Promise.resolve();
+    const next = previous.then(call, call);
+    // Keep the queue alive regardless of how this call settles so one failure
+    // does not block later calls on the same context.
+    preparedContextQueues.set(preparedContext, next.catch(() => undefined));
+    return next;
 }
 
 function clonePreparedContextBuilder(
@@ -292,9 +294,9 @@ function clonePreparedContextBuilder(
 /**
  * A reusable program context created by {@link ProgramManager.prepareProgram}.
  *
- * The context is scoped to one program function. Calls using it must be
- * sequential. The caller owns the context and should call {@link free} when it
- * is no longer needed.
+ * The context is scoped to one program function. Concurrent calls sharing it
+ * are serialized at the WASM boundary. The caller owns the context and should
+ * call {@link free} when it is no longer needed.
  */
 class PreparedProgram {
     readonly programName: string;
@@ -323,6 +325,7 @@ class PreparedProgram {
     free(): void {
         preparedContextBuilders.get(this)?.free();
         preparedContextBuilders.delete(this);
+        preparedProgramImports.delete(this);
     }
 }
 
@@ -331,7 +334,8 @@ class PreparedProgram {
  *
  * Unlike {@link PreparedProgram}, a prepared process can authorize any
  * function in any loaded program. Extra loaded programs remain idle when a
- * call only needs a subset. Calls sharing the process must be sequential.
+ * call only needs a subset. Concurrent calls sharing the process are
+ * serialized at the WASM boundary.
  */
 class PreparedProcess {
     readonly programs: readonly PreparedProcessProgram[];
@@ -722,6 +726,15 @@ class ProgramManager {
         // fully initialized before an authorization is requested.
         builder.addProgram(options.programName, program, edition);
 
+        // Snapshot the import sources once so later validation is answered from
+        // JavaScript and never borrows the shared WASM process.
+        const importSources = new Map<string, string>();
+        for (const name of Array.from(builder.programNames())) {
+            if (name === options.programName) continue;
+            const source = builder.getProgram(name);
+            if (source !== undefined) importSources.set(name, source);
+        }
+
         const preparedProgram = new PreparedProgram(
             options.programName,
             options.functionName,
@@ -729,6 +742,7 @@ class ProgramManager {
             edition,
         );
         preparedContextBuilders.set(preparedProgram, builder);
+        preparedProgramImports.set(preparedProgram, importSources);
         return preparedProgram;
     }
 
@@ -939,17 +953,16 @@ class ProgramManager {
         }
 
         if (options.programImports) {
-            const builder = clonePreparedContextBuilder(preparedProgram);
-            try {
-                for (const [name, source] of Object.entries(options.programImports)) {
-                    if (builder.getProgram(name) !== normalizeProgramSource(source)) {
-                        throw new Error(
-                            `Prepared program import '${name}' does not match the supplied import`,
-                        );
-                    }
+            const importSources = preparedProgramImports.get(preparedProgram);
+            if (!importSources || !preparedContextBuilders.has(preparedProgram)) {
+                throw new Error("Prepared program has already been freed");
+            }
+            for (const [name, source] of Object.entries(options.programImports)) {
+                if (importSources.get(name) !== normalizeProgramSource(source)) {
+                    throw new Error(
+                        `Prepared program import '${name}' does not match the supplied import`,
+                    );
                 }
-            } finally {
-                builder.free();
             }
         }
     }
@@ -2238,13 +2251,6 @@ class ProgramManager {
     async buildAuthorization(
         options: AuthorizationOptions,
     ): Promise<Authorization> {
-        return withPreparedContext(selectedPreparedContext(options), () =>
-            this.buildAuthorizationInner(options));
-    }
-
-    private async buildAuthorizationInner(
-        options: AuthorizationOptions,
-    ): Promise<Authorization> {
         // Destructure the options object to access the parameters.
         const {
             functionName,
@@ -2309,15 +2315,16 @@ class ProgramManager {
         const hasImports = !builder.isEmpty();
 
         // Build and return an `Authorization` for the desired function.
-        const authorization = await WasmProgramManager.authorize(
-            executionPrivateKey,
-            program,
-            functionName,
-            preparedInputs,
-            hasPreparedContext || hasImports ? undefined : imports,
-            edition,
-            hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
-        );
+        const authorization = await withPreparedContextWasm(preparedCall?.context, () =>
+            WasmProgramManager.authorize(
+                executionPrivateKey,
+                program,
+                functionName,
+                preparedInputs,
+                hasPreparedContext || hasImports ? undefined : imports,
+                edition,
+                hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
+            ));
 
         return authorization;
     }
@@ -2353,13 +2360,6 @@ class ProgramManager {
     async buildAuthorizationUnchecked(
         options: AuthorizationOptions,
     ): Promise<Authorization> {
-        return withPreparedContext(selectedPreparedContext(options), () =>
-            this.buildAuthorizationUncheckedInner(options));
-    }
-
-    private async buildAuthorizationUncheckedInner(
-        options: AuthorizationOptions,
-    ): Promise<Authorization> {
         // Destructure the options object to access the parameters.
         const {
             functionName,
@@ -2424,15 +2424,16 @@ class ProgramManager {
         const hasImports = !builder.isEmpty();
 
         // Build and return an `Authorization` for the desired function.
-        const authorization = await WasmProgramManager.buildAuthorizationUnchecked(
-            executionPrivateKey,
-            program,
-            functionName,
-            preparedInputs,
-            hasPreparedContext || hasImports ? undefined : imports,
-            edition,
-            hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
-        );
+        const authorization = await withPreparedContextWasm(preparedCall?.context, () =>
+            WasmProgramManager.buildAuthorizationUnchecked(
+                executionPrivateKey,
+                program,
+                functionName,
+                preparedInputs,
+                hasPreparedContext || hasImports ? undefined : imports,
+                edition,
+                hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
+            ));
 
         return authorization;
     }
@@ -2469,13 +2470,6 @@ class ProgramManager {
      * });
      */
     async provingRequest(
-        options: ProvingRequestOptions,
-    ): Promise<ProvingRequest> {
-        return withPreparedContext(selectedPreparedContext(options), () =>
-            this.provingRequestInner(options));
-    }
-
-    private async provingRequestInner(
         options: ProvingRequestOptions,
     ): Promise<ProvingRequest> {
         // Destructure the options object to access the parameters.
@@ -2568,13 +2562,14 @@ class ProgramManager {
                 let fee = priorityFee;
                 // If a fee record wasn't provided, estimate the fee that needs to be paid.
                 if (!feeRecord) {
-                    const baseFee = Number(await WasmProgramManager.estimateExecutionFee(
-                        program,
-                        functionName,
-                        hasProcessBuilder ? undefined : imports,
-                        edition,
-                        hasProcessBuilder ? builder.clone() : undefined,
-                    ));
+                    const baseFee = Number(await withPreparedContextWasm(preparedCall?.context, async () =>
+                        WasmProgramManager.estimateExecutionFee(
+                            program,
+                            functionName,
+                            hasProcessBuilder ? undefined : imports,
+                            edition,
+                            hasProcessBuilder ? builder.clone() : undefined,
+                        )));
                     fee = baseFee + priorityFee;
                 }
 
@@ -2596,16 +2591,17 @@ class ProgramManager {
         }
 
         if (options.executionRequest instanceof ExecutionRequest) {
-            return await WasmProgramManager.buildProvingRequestFromExecutionRequest(
-                options.executionRequest,
-                program,
-                unchecked,
-                broadcast,
-                edition,
-                hasProcessBuilder ? undefined : imports,
-                executionPrivateKey,
-                hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
-            );
+            return await withPreparedContextWasm(preparedCall?.context, () =>
+                WasmProgramManager.buildProvingRequestFromExecutionRequest(
+                    options.executionRequest as ExecutionRequest,
+                    program,
+                    unchecked,
+                    broadcast,
+                    edition,
+                    hasProcessBuilder ? undefined : imports,
+                    executionPrivateKey,
+                    hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
+                ));
         } else {
             // Ensure the private key exists.
             if (!executionPrivateKey) {
@@ -2621,21 +2617,22 @@ class ProgramManager {
             const preparedInputs = this.prepareInputs(program, functionName, inputs);
 
             // Build and return the `ProvingRequest`.
-            return await WasmProgramManager.buildProvingRequest(
-                executionPrivateKey,
-                program,
-                functionName,
-                preparedInputs,
-                baseFee,
-                priorityFee,
-                feeRecord,
-                hasProcessBuilder ? undefined : imports,
-                broadcast,
-                unchecked,
-                edition,
-                useFeeMaster,
-                hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
-            );
+            return await withPreparedContextWasm(preparedCall?.context, () =>
+                WasmProgramManager.buildProvingRequest(
+                    executionPrivateKey,
+                    program,
+                    functionName,
+                    preparedInputs,
+                    baseFee,
+                    priorityFee,
+                    feeRecord,
+                    hasProcessBuilder ? undefined : imports,
+                    broadcast,
+                    unchecked,
+                    edition,
+                    useFeeMaster,
+                    hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
+                ));
         }
     }
 

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -805,10 +805,22 @@ class ProgramManager {
             editions.set(program.programName, program.edition);
         }
 
+        // Treat every explicitly requested program as already known while
+        // resolving imports for its siblings. Otherwise, a requested program
+        // that statically imports another requested program would fetch that
+        // sibling from the network again and could conflict with the source
+        // supplied by the caller.
+        const knownProgramSources: ProgramImports = {
+            ...Object.fromEntries(requestedPrograms.map((program) => [
+                program.programName,
+                program.programSource,
+            ])),
+            ...(options.programImports ?? {}),
+        };
         const collectedImports = await Promise.all(requestedPrograms.map((program) =>
             this.collectProgramImports(
                 program.programSource,
-                options.programImports,
+                knownProgramSources,
                 true,
             )
         ));

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -141,31 +141,152 @@ interface PrepareProgramOptions {
     edition?: number;
 }
 
-const preparedProgramBuilders = new WeakMap<object, ProgramImportsBuilder>();
+/**
+ * A program to load into a reusable {@link PreparedProcess}.
+ *
+ * @property programName Program name (e.g. "credits.aleo").
+ * @property programSource Optional source. When omitted, it is fetched from
+ *   the network.
+ * @property edition Optional edition. When omitted, the current on-chain
+ *   edition is resolved.
+ */
+interface ProgramPreparationOptions {
+    programName: string;
+    programSource?: string | Program;
+    edition?: number;
+}
 
-function clonePreparedProgramBuilder(
-    preparedProgram: PreparedProgram,
+/**
+ * Options for preparing one snarkVM process that can serve multiple programs
+ * and functions.
+ *
+ * `programImports` may contain a superset of dynamic-dispatch targets. Calls
+ * can later provide and use any matching subset without rebuilding the
+ * process.
+ */
+interface PrepareProcessOptions {
+    programs: ProgramPreparationOptions[];
+    programImports?: ProgramImports;
+}
+
+/** Metadata for a program loaded into a {@link PreparedProcess}. */
+interface PreparedProcessProgram {
+    readonly programName: string;
+    readonly programSource: string;
+    readonly edition: number;
+    readonly functions: readonly string[];
+}
+
+/** Options accepted by {@link PreparedProcess.supports}. */
+interface PreparedProcessSupportsOptions {
+    programName: string;
+    functionName?: string;
+    programSource?: string | Program;
+    programImports?: ProgramImports;
+    edition?: number;
+}
+
+type PreparedContext = PreparedProgram | PreparedProcess;
+
+interface PreparedCallContext {
+    context: PreparedContext;
+    programName: string;
+    programSource: string;
+    edition: number;
+}
+
+const preparedContextBuilders = new WeakMap<object, ProgramImportsBuilder>();
+const preparedProcessPrograms = new WeakMap<object, Map<string, PreparedProcessProgram>>();
+const busyPreparedContexts = new WeakSet<object>();
+
+function normalizeProgramSource(program: string | Program): string {
+    return program instanceof Program ? program.toString() : program;
+}
+
+function preparedProcessSupports(
+    preparedProcess: PreparedProcess,
+    options: PreparedProcessSupportsOptions,
+): boolean {
+    const programs = preparedProcessPrograms.get(preparedProcess);
+    const builder = preparedContextBuilders.get(preparedProcess);
+    if (!programs || !builder) return false;
+
+    const program = programs.get(options.programName);
+    if (!program) return false;
+    if (
+        options.functionName !== undefined
+        && !program.functions.includes(options.functionName)
+    ) {
+        return false;
+    }
+    if (
+        options.programSource !== undefined
+        && normalizeProgramSource(options.programSource) !== program.programSource
+    ) {
+        return false;
+    }
+    if (options.edition !== undefined && options.edition !== program.edition) {
+        return false;
+    }
+    if (options.programImports) {
+        for (const [name, source] of Object.entries(options.programImports)) {
+            if (programs.get(name)?.programSource !== normalizeProgramSource(source)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+function selectedPreparedContext(options: {
+    preparedProgram?: PreparedProgram;
+    preparedProcess?: PreparedProcess;
+}): PreparedContext | undefined {
+    if (options.preparedProgram && options.preparedProcess) {
+        throw new Error("Specify either preparedProgram or preparedProcess, not both");
+    }
+    return options.preparedProcess ?? options.preparedProgram;
+}
+
+/**
+ * Run an action while holding exclusive use of a prepared context.
+ *
+ * WASM builder clones are reference-counted handles to one mutable snarkVM
+ * process. Concurrent calls would otherwise cause a RefCell borrow panic and
+ * abort the WASM module, so reject them with a catchable error instead.
+ */
+async function withPreparedContext<T>(
+    preparedContext: PreparedContext | undefined,
+    action: () => Promise<T>,
+): Promise<T> {
+    if (!preparedContext) return action();
+    if (busyPreparedContexts.has(preparedContext)) {
+        throw new Error(
+            "Prepared context is already in use; calls sharing a prepared context must be sequential",
+        );
+    }
+    busyPreparedContexts.add(preparedContext);
+    try {
+        return await action();
+    } finally {
+        busyPreparedContexts.delete(preparedContext);
+    }
+}
+
+function clonePreparedContextBuilder(
+    preparedContext: PreparedContext,
 ): ProgramImportsBuilder {
-    const builder = preparedProgramBuilders.get(preparedProgram);
+    const builder = preparedContextBuilders.get(preparedContext);
     if (!builder) {
-        throw new Error("Prepared program has already been freed");
+        throw new Error(
+            preparedContext instanceof PreparedProcess
+                ? "Prepared process has already been freed"
+                : "Prepared program has already been freed",
+        );
     }
     // The WASM clone is a cheap shared Rc handle, not a deep copy. Mutations
     // made while authorizing intentionally remain cached in the prepared context.
     return builder.clone();
-}
-
-function programImportsFromBuilder(
-    builder: ProgramImportsBuilder,
-    entryProgramName: string,
-): ProgramImports {
-    const imports: ProgramImports = {};
-    for (const name of Array.from(builder.programNames())) {
-        if (name === entryProgramName) continue;
-        const source = builder.getProgram(name);
-        if (source) imports[name] = source;
-    }
-    return imports;
 }
 
 /**
@@ -200,8 +321,48 @@ class PreparedProgram {
      * Release the prepared snarkVM process. This method is idempotent.
      */
     free(): void {
-        preparedProgramBuilders.get(this)?.free();
-        preparedProgramBuilders.delete(this);
+        preparedContextBuilders.get(this)?.free();
+        preparedContextBuilders.delete(this);
+    }
+}
+
+/**
+ * A reusable snarkVM process created by {@link ProgramManager.prepareProcess}.
+ *
+ * Unlike {@link PreparedProgram}, a prepared process can authorize any
+ * function in any loaded program. Extra loaded programs remain idle when a
+ * call only needs a subset. Calls sharing the process must be sequential.
+ */
+class PreparedProcess {
+    readonly programs: readonly PreparedProcessProgram[];
+
+    /** Instances are normally created through {@link ProgramManager.prepareProcess}. */
+    constructor(programs: readonly PreparedProcessProgram[]) {
+        this.programs = Object.freeze(programs.map((program) => Object.freeze({
+            ...program,
+            functions: Object.freeze([...program.functions]),
+        })));
+    }
+
+    /** Names of all programs loaded into this process. */
+    get programNames(): readonly string[] {
+        return this.programs.map(({ programName }) => programName);
+    }
+
+    /**
+     * Check whether the process can serve a call without network resolution or
+     * process rebuilding. Caller-provided imports may be a subset of the
+     * programs loaded into the process.
+     */
+    supports(options: PreparedProcessSupportsOptions): boolean {
+        return preparedProcessSupports(this, options);
+    }
+
+    /** Release the prepared snarkVM process. This method is idempotent. */
+    free(): void {
+        preparedContextBuilders.get(this)?.free();
+        preparedContextBuilders.delete(this);
+        preparedProcessPrograms.delete(this);
     }
 }
 
@@ -216,6 +377,7 @@ class PreparedProgram {
  * @property {ProgramImports} [programImports] The other programs the program imports.
  * @property {edition} [edition]
  * @property {PreparedProgram} [preparedProgram] A reusable context returned by ProgramManager.prepareProgram.
+ * @property {PreparedProcess} [preparedProcess] A multi-program context returned by ProgramManager.prepareProcess.
  */
 interface AuthorizationOptions {
     programName: string;
@@ -226,6 +388,7 @@ interface AuthorizationOptions {
     programImports?: ProgramImports;
     edition?: number;
     preparedProgram?: PreparedProgram;
+    preparedProcess?: PreparedProcess;
 }
 
 /**
@@ -291,6 +454,7 @@ interface ExecuteAuthorizationOptions {
  * @property {number} [edition] - Edition of the program to execute the function in.
  * @property {boolean} [useFeeMaster] - Whether to use the FeeMaster account to execute the transaction.
  * @property {PreparedProgram} [preparedProgram] - A reusable context returned by ProgramManager.prepareProgram.
+ * @property {PreparedProcess} [preparedProcess] - A reusable multi-program context returned by ProgramManager.prepareProcess.
  */
 interface ProvingRequestOptions {
     programName: string;
@@ -310,6 +474,7 @@ interface ProvingRequestOptions {
     useFeeMaster?: boolean;
     executionRequest?: ExecutionRequest;
     preparedProgram?: PreparedProgram;
+    preparedProcess?: PreparedProcess;
 }
 
 /**
@@ -529,15 +694,19 @@ class ProgramManager {
         }
 
         const parsedProgram = Program.fromString(program);
-        if (parsedProgram.id() !== options.programName) {
-            throw new Error(
-                `Program source ID '${parsedProgram.id()}' does not match requested program '${options.programName}'`,
-            );
-        }
-        if (!parsedProgram.getFunctions().includes(options.functionName)) {
-            throw new Error(
-                `Function '${options.functionName}' does not exist in program '${options.programName}'`,
-            );
+        try {
+            if (parsedProgram.id() !== options.programName) {
+                throw new Error(
+                    `Program source ID '${parsedProgram.id()}' does not match requested program '${options.programName}'`,
+                );
+            }
+            if (!parsedProgram.getFunctions().includes(options.functionName)) {
+                throw new Error(
+                    `Function '${options.functionName}' does not exist in program '${options.programName}'`,
+                );
+            }
+        } finally {
+            parsedProgram.free();
         }
 
         const edition = options.edition
@@ -559,8 +728,166 @@ class ProgramManager {
             program,
             edition,
         );
-        preparedProgramBuilders.set(preparedProgram, builder);
+        preparedContextBuilders.set(preparedProgram, builder);
         return preparedProgram;
+    }
+
+    /**
+     * Prepare one reusable snarkVM process for multiple programs and functions.
+     *
+     * Sources, editions, and transitive imports are resolved once. Every
+     * loaded program can later be used as an entry program, and an invocation
+     * may supply any matching subset of the preloaded imports.
+     *
+     * @example
+     * const prepared = await programManager.prepareProcess({
+     *     programs: [
+     *         { programName: "wallet_router.aleo" },
+     *         { programName: "token_registry.aleo" },
+     *     ],
+     *     programImports: dynamicDispatchTargets,
+     * });
+     * try {
+     *     const authorization = await programManager.buildAuthorizationUnchecked({
+     *         programName: "wallet_router.aleo",
+     *         functionName: "transfer",
+     *         inputs,
+     *         preparedProcess: prepared,
+     *     });
+     * } finally {
+     *     prepared.free();
+     * }
+     */
+    async prepareProcess(
+        options: PrepareProcessOptions,
+    ): Promise<PreparedProcess> {
+        if (!Array.isArray(options.programs) || options.programs.length === 0) {
+            throw new Error("At least one program is required to prepare a process");
+        }
+
+        const requestedNames = new Set<string>();
+        for (const program of options.programs) {
+            if (requestedNames.has(program.programName)) {
+                throw new Error(`Program '${program.programName}' was requested more than once`);
+            }
+            requestedNames.add(program.programName);
+        }
+
+        const requestedPrograms = await Promise.all(options.programs.map(async (requested) => {
+            let source = requested.programSource;
+            if (source === undefined) {
+                try {
+                    source = await this.networkClient.getProgram(requested.programName);
+                } catch (e: any) {
+                    logAndThrow(
+                        `Error finding ${requested.programName}. Network response: '${e.message}'. Please ensure you're connected to a valid Aleo network the program is deployed to the network.`,
+                    );
+                }
+            }
+            const programSource = normalizeProgramSource(source);
+            const edition = requested.edition
+                ?? (await this.resolveEditionAndAmendment(requested.programName)).edition;
+            return { programName: requested.programName, programSource, edition };
+        }));
+
+        const sources = new Map<string, string>();
+        const editions = new Map<string, number>();
+        const mergeSource = (name: string, source: string) => {
+            const existing = sources.get(name);
+            if (existing !== undefined && existing !== source) {
+                throw new Error(`Conflicting sources were supplied for program '${name}'`);
+            }
+            sources.set(name, source);
+        };
+
+        for (const program of requestedPrograms) {
+            mergeSource(program.programName, program.programSource);
+            editions.set(program.programName, program.edition);
+        }
+
+        const collectedImports = await Promise.all(requestedPrograms.map((program) =>
+            this.collectProgramImports(
+                program.programSource,
+                options.programImports,
+                true,
+            )
+        ));
+        for (const imports of collectedImports) {
+            for (const [name, source] of imports) mergeSource(name, source);
+        }
+
+        const functions = new Map<string, readonly string[]>();
+        const staticImports = new Map<string, readonly string[]>();
+        for (const [name, source] of sources) {
+            const parsed = Program.fromString(source);
+            try {
+                if (parsed.id() !== name) {
+                    throw new Error(
+                        `Program source ID '${parsed.id()}' does not match supplied program name '${name}'`,
+                    );
+                }
+                functions.set(name, Object.freeze(Array.from(parsed.getFunctions())));
+                staticImports.set(name, Object.freeze(Array.from(parsed.getImports())));
+            } finally {
+                parsed.free();
+            }
+        }
+
+        for (const [name, imports] of staticImports) {
+            for (const importedName of imports) {
+                if (importedName !== "credits.aleo" && !sources.has(importedName)) {
+                    throw new Error(`Missing import '${importedName}' required by program '${name}'`);
+                }
+            }
+        }
+
+        await Promise.all(Array.from(sources.keys()).map(async (name) => {
+            if (!editions.has(name)) {
+                editions.set(name, (await this.resolveEditionAndAmendment(name)).edition);
+            }
+        }));
+
+        const sortedNames: string[] = [];
+        const visited = new Set<string>();
+        const visiting = new Set<string>();
+        const visit = (name: string) => {
+            if (visited.has(name)) return;
+            if (visiting.has(name)) {
+                throw new Error(`Cyclic program imports include '${name}'`);
+            }
+            visiting.add(name);
+            for (const dependency of staticImports.get(name) ?? []) {
+                if (sources.has(dependency)) visit(dependency);
+            }
+            visiting.delete(name);
+            visited.add(name);
+            sortedNames.push(name);
+        };
+        for (const name of sources.keys()) visit(name);
+
+        const builder = new ProgramImportsBuilder();
+        try {
+            for (const name of sortedNames) {
+                builder.addProgram(name, sources.get(name)!, editions.get(name)!);
+            }
+        } catch (e) {
+            builder.free();
+            throw e;
+        }
+
+        const processPrograms = sortedNames.map((name): PreparedProcessProgram => ({
+            programName: name,
+            programSource: sources.get(name)!,
+            edition: editions.get(name)!,
+            functions: functions.get(name)!,
+        }));
+        const preparedProcess = new PreparedProcess(processPrograms);
+        preparedContextBuilders.set(preparedProcess, builder);
+        preparedProcessPrograms.set(
+            preparedProcess,
+            new Map(preparedProcess.programs.map((program) => [program.programName, program])),
+        );
+        return preparedProcess;
     }
 
     private validatePreparedProgram(
@@ -600,10 +927,10 @@ class ProgramManager {
         }
 
         if (options.programImports) {
-            const builder = clonePreparedProgramBuilder(preparedProgram);
+            const builder = clonePreparedContextBuilder(preparedProgram);
             try {
                 for (const [name, source] of Object.entries(options.programImports)) {
-                    if (builder.getProgram(name) !== source.toString()) {
+                    if (builder.getProgram(name) !== normalizeProgramSource(source)) {
                         throw new Error(
                             `Prepared program import '${name}' does not match the supplied import`,
                         );
@@ -613,6 +940,79 @@ class ProgramManager {
                 builder.free();
             }
         }
+    }
+
+    private validatePreparedProcess(
+        preparedProcess: PreparedProcess,
+        options: {
+            programName: string;
+            functionName: string;
+            programSource?: string | Program;
+            programImports?: ProgramImports;
+            edition?: number;
+        },
+    ): PreparedProcessProgram {
+        const programs = preparedProcessPrograms.get(preparedProcess);
+        if (!programs || !preparedContextBuilders.has(preparedProcess)) {
+            throw new Error("Prepared process has already been freed");
+        }
+        const program = programs.get(options.programName);
+        if (!program) {
+            throw new Error(`Prepared process does not contain program '${options.programName}'`);
+        }
+        if (!program.functions.includes(options.functionName)) {
+            throw new Error(
+                `Prepared process does not contain function '${options.programName}/${options.functionName}'`,
+            );
+        }
+        if (
+            options.programSource !== undefined
+            && normalizeProgramSource(options.programSource) !== program.programSource
+        ) {
+            throw new Error("Prepared process source does not match the supplied program source");
+        }
+        if (options.edition !== undefined && options.edition !== program.edition) {
+            throw new Error("Prepared process edition does not match the supplied edition");
+        }
+        if (options.programImports) {
+            for (const [name, source] of Object.entries(options.programImports)) {
+                if (programs.get(name)?.programSource !== normalizeProgramSource(source)) {
+                    throw new Error(
+                        `Prepared process import '${name}' does not match a loaded program`,
+                    );
+                }
+            }
+        }
+        return program;
+    }
+
+    private preparedCallContext(options: {
+        programName: string;
+        functionName: string;
+        programSource?: string | Program;
+        programImports?: ProgramImports;
+        edition?: number;
+        preparedProgram?: PreparedProgram;
+        preparedProcess?: PreparedProcess;
+    }): PreparedCallContext | undefined {
+        const context = selectedPreparedContext(options);
+        if (!context) return undefined;
+        if (context instanceof PreparedProcess) {
+            const program = this.validatePreparedProcess(context, options);
+            return {
+                context,
+                programName: program.programName,
+                programSource: program.programSource,
+                edition: program.edition,
+            };
+        }
+        this.validatePreparedProgram(context, options);
+        return {
+            context,
+            programName: context.programName,
+            programSource: context.programSource,
+            edition: context.edition,
+        };
     }
 
     /**
@@ -1826,22 +2226,26 @@ class ProgramManager {
     async buildAuthorization(
         options: AuthorizationOptions,
     ): Promise<Authorization> {
+        return withPreparedContext(selectedPreparedContext(options), () =>
+            this.buildAuthorizationInner(options));
+    }
+
+    private async buildAuthorizationInner(
+        options: AuthorizationOptions,
+    ): Promise<Authorization> {
         // Destructure the options object to access the parameters.
         const {
             functionName,
             inputs,
         } = options;
 
-        const preparedProgram = options.preparedProgram;
-        if (preparedProgram) {
-            this.validatePreparedProgram(preparedProgram, options);
-        }
+        const preparedCall = this.preparedCallContext(options);
 
         const privateKey = options.privateKey;
-        let program = preparedProgram?.programSource ?? options.programSource;
-        let programName = preparedProgram?.programName ?? options.programName;
+        let program = preparedCall?.programSource ?? options.programSource;
+        let programName = preparedCall?.programName ?? options.programName;
         const imports = options.programImports;
-        let edition = preparedProgram?.edition ?? options.edition;
+        let edition = preparedCall?.edition ?? options.edition;
 
         // Ensure the function exists on the network.
         if (program === undefined) {
@@ -1876,7 +2280,7 @@ class ProgramManager {
             throw "No private key provided and no private key set in the ProgramManager";
         }
 
-        if (!preparedProgram) {
+        if (!preparedCall) {
             const resolved = await this.resolveEditionAndAmendment(programName, edition);
             edition = edition ?? resolved.edition;
         }
@@ -1886,10 +2290,10 @@ class ProgramManager {
 
         // Build ProgramImportsBuilder for import resolution (no key loading —
         // authorizations don't synthesize keys).
-        const builder = preparedProgram
-            ? clonePreparedProgramBuilder(preparedProgram)
+        const builder = preparedCall
+            ? clonePreparedContextBuilder(preparedCall.context)
             : (await this.buildProgramImports(program, imports, false, functionName)).builder;
-        const hasPreparedProcess = preparedProgram !== undefined;
+        const hasPreparedContext = preparedCall !== undefined;
         const hasImports = !builder.isEmpty();
 
         // Build and return an `Authorization` for the desired function.
@@ -1898,9 +2302,9 @@ class ProgramManager {
             program,
             functionName,
             preparedInputs,
-            hasPreparedProcess || hasImports ? undefined : imports,
+            hasPreparedContext || hasImports ? undefined : imports,
             edition,
-            hasPreparedProcess ? builder : hasImports ? builder.clone() : undefined,
+            hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
         );
 
         return authorization;
@@ -1937,22 +2341,26 @@ class ProgramManager {
     async buildAuthorizationUnchecked(
         options: AuthorizationOptions,
     ): Promise<Authorization> {
+        return withPreparedContext(selectedPreparedContext(options), () =>
+            this.buildAuthorizationUncheckedInner(options));
+    }
+
+    private async buildAuthorizationUncheckedInner(
+        options: AuthorizationOptions,
+    ): Promise<Authorization> {
         // Destructure the options object to access the parameters.
         const {
             functionName,
             inputs,
         } = options;
 
-        const preparedProgram = options.preparedProgram;
-        if (preparedProgram) {
-            this.validatePreparedProgram(preparedProgram, options);
-        }
+        const preparedCall = this.preparedCallContext(options);
 
         const privateKey = options.privateKey;
-        let program = preparedProgram?.programSource ?? options.programSource;
-        let programName = preparedProgram?.programName ?? options.programName;
+        let program = preparedCall?.programSource ?? options.programSource;
+        let programName = preparedCall?.programName ?? options.programName;
         const imports = options.programImports;
-        let edition = preparedProgram?.edition ?? options.edition;
+        let edition = preparedCall?.edition ?? options.edition;
 
         // Ensure the function exists on the network.
         if (program === undefined) {
@@ -1987,7 +2395,7 @@ class ProgramManager {
             throw "No private key provided and no private key set in the ProgramManager";
         }
 
-        if (!preparedProgram) {
+        if (!preparedCall) {
             const resolved = await this.resolveEditionAndAmendment(programName, edition);
             edition = edition ?? resolved.edition;
         }
@@ -1997,10 +2405,10 @@ class ProgramManager {
 
         // Build ProgramImportsBuilder for import resolution (no key loading —
         // authorizations don't synthesize keys).
-        const builder = preparedProgram
-            ? clonePreparedProgramBuilder(preparedProgram)
+        const builder = preparedCall
+            ? clonePreparedContextBuilder(preparedCall.context)
             : (await this.buildProgramImports(program, imports, false, functionName)).builder;
-        const hasPreparedProcess = preparedProgram !== undefined;
+        const hasPreparedContext = preparedCall !== undefined;
         const hasImports = !builder.isEmpty();
 
         // Build and return an `Authorization` for the desired function.
@@ -2009,9 +2417,9 @@ class ProgramManager {
             program,
             functionName,
             preparedInputs,
-            hasPreparedProcess || hasImports ? undefined : imports,
+            hasPreparedContext || hasImports ? undefined : imports,
             edition,
-            hasPreparedProcess ? builder : hasImports ? builder.clone() : undefined,
+            hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
         );
 
         return authorization;
@@ -2051,6 +2459,13 @@ class ProgramManager {
     async provingRequest(
         options: ProvingRequestOptions,
     ): Promise<ProvingRequest> {
+        return withPreparedContext(selectedPreparedContext(options), () =>
+            this.provingRequestInner(options));
+    }
+
+    private async provingRequestInner(
+        options: ProvingRequestOptions,
+    ): Promise<ProvingRequest> {
         // Destructure the options object to access the parameters.
         const {
             functionName,
@@ -2062,19 +2477,16 @@ class ProgramManager {
             unchecked = false,
         } = options;
 
-        const preparedProgram = options.preparedProgram;
-        if (preparedProgram) {
-            this.validatePreparedProgram(preparedProgram, options);
-        }
+        const preparedCall = this.preparedCallContext(options);
 
         const baseFee = options.baseFee ? options.baseFee : 0;
         const privateKey = options.privateKey;
         const useFeeMaster = options.useFeeMaster ? options.useFeeMaster : false;
-        let program = preparedProgram?.programSource ?? options.programSource;
-        let programName = preparedProgram?.programName ?? options.programName;
+        let program = preparedCall?.programSource ?? options.programSource;
+        let programName = preparedCall?.programName ?? options.programName;
         let feeRecord = options.feeRecord;
         let imports = options.programImports;
-        let edition = preparedProgram?.edition ?? options.edition;
+        let edition = preparedCall?.edition ?? options.edition;
 
         if (!inputs && !options.executionRequest) {
             throw new Error("Either function inputs or an execution request must be provided to form a proving request");
@@ -2100,7 +2512,7 @@ class ProgramManager {
             programName = Program.fromString(program).id();
         }
 
-        if (!preparedProgram) {
+        if (!preparedCall) {
             const resolved = await this.resolveEditionAndAmendment(programName, edition);
             edition = edition ?? resolved.edition;
         }
@@ -2116,8 +2528,8 @@ class ProgramManager {
         }
 
         // Resolve the program imports if they exist.
-        const numberOfImports = Program.fromString(program).getImports().length;
-        if (!preparedProgram && numberOfImports > 0 && !imports) {
+        const numberOfImports = ProgramManager.getImportNames(program).length;
+        if (!preparedCall && numberOfImports > 0 && !imports) {
             try {
                 imports = <ProgramImports>(
                     await this.networkClient.getProgramImports(programName)
@@ -2131,28 +2543,12 @@ class ProgramManager {
 
         // Build ProgramImportsBuilder for import resolution (no key loading —
         // proving requests don't synthesize keys).
-        const builder = preparedProgram
-            ? clonePreparedProgramBuilder(preparedProgram)
+        const builder = preparedCall
+            ? clonePreparedContextBuilder(preparedCall.context)
             : (await this.buildProgramImports(program, imports, false, functionName)).builder;
-        const hasPreparedProcess = preparedProgram !== undefined;
+        const hasPreparedContext = preparedCall !== undefined;
         const hasImports = !builder.isEmpty();
-
-        // Normalize imports once to the full merged set from the builder so
-        // both the private-fee estimate below and the Rust-side fee estimator
-        // (estimate_fee_for_authorization uses the legacy imports Object to
-        // avoid a RefCell double-borrow — see proving_request.rs) see all
-        // transitive imports, not just the caller's partial set. Use
-        // programNames + getProgram to avoid serializing key bytes (toObject
-        // would serialize all proving/verifying keys, which can be tens of
-        // MB). The prepared executionRequest path skips the copy: it passes
-        // the process builder directly and never estimates fees, so the
-        // imports Object goes unused there.
-        const importsObjectUnused =
-            hasPreparedProcess
-            && options.executionRequest instanceof ExecutionRequest;
-        if ((hasPreparedProcess || hasImports) && !importsObjectUnused) {
-            imports = programImportsFromBuilder(builder, programName);
-        }
+        const hasProcessBuilder = hasPreparedContext || hasImports;
 
         // Get the fee record from the account if it is not provided in the parameters
         try {
@@ -2160,7 +2556,13 @@ class ProgramManager {
                 let fee = priorityFee;
                 // If a fee record wasn't provided, estimate the fee that needs to be paid.
                 if (!feeRecord) {
-                    const baseFee = Number(await this.estimateExecutionFee({programName, functionName, program: program.toString(), imports}));
+                    const baseFee = Number(await WasmProgramManager.estimateExecutionFee(
+                        program,
+                        functionName,
+                        hasProcessBuilder ? undefined : imports,
+                        edition,
+                        hasProcessBuilder ? builder.clone() : undefined,
+                    ));
                     fee = baseFee + priorityFee;
                 }
 
@@ -2188,11 +2590,9 @@ class ProgramManager {
                 unchecked,
                 broadcast,
                 edition,
-                // The prepared process supersedes the legacy imports Object;
-                // without one, imports is kept for fee estimation in Rust.
-                hasPreparedProcess ? undefined : imports,
+                hasProcessBuilder ? undefined : imports,
                 executionPrivateKey,
-                hasPreparedProcess ? builder : hasImports ? builder.clone() : undefined,
+                hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
             );
         } else {
             // Ensure the private key exists.
@@ -2217,12 +2617,12 @@ class ProgramManager {
                 baseFee,
                 priorityFee,
                 feeRecord,
-                imports, // kept for fee estimation in Rust
+                hasProcessBuilder ? undefined : imports,
                 broadcast,
                 unchecked,
                 edition,
                 useFeeMaster,
-                hasPreparedProcess ? builder : hasImports ? builder.clone() : undefined,
+                hasPreparedContext ? builder : hasImports ? builder.clone() : undefined,
             );
         }
     }
@@ -4640,4 +5040,4 @@ function programChecksum(program: string | Program): Uint8Array {
     }
 }
 
-export { ProgramManager, PreparedProgram, PrepareProgramOptions, AuthorizationOptions, FeeAuthorizationOptions, ExecuteOptions, ProvingRequestOptions, ExternalSigningOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof, programChecksum };
+export { ProgramManager, PreparedProgram, PreparedProcess, PrepareProgramOptions, ProgramPreparationOptions, PrepareProcessOptions, PreparedProcessProgram, PreparedProcessSupportsOptions, AuthorizationOptions, FeeAuthorizationOptions, ExecuteOptions, ProvingRequestOptions, ExternalSigningOptions, VerificationOptions, BatchVerificationOptions, inputsToFields, verifyProof, verifyBatchProof, programChecksum };

--- a/sdk/src/program-manager.ts
+++ b/sdk/src/program-manager.ts
@@ -200,9 +200,40 @@ const preparedProcessPrograms = new WeakMap<object, Map<string, PreparedProcessP
 const preparedProgramImports = new WeakMap<object, Map<string, string>>();
 const preparedContextQueues = new WeakMap<object, Promise<void>>();
 const CREDITS_PROGRAM_ID = "credits.aleo";
+let canonicalCreditsProgramSource: string | undefined;
 
 function normalizeProgramSource(program: string | Program): string {
     return program instanceof Program ? program.toString() : program;
+}
+
+function getCanonicalCreditsProgramSource(): string {
+    if (canonicalCreditsProgramSource === undefined) {
+        const creditsProgram = Program.getCreditsProgram();
+        try {
+            canonicalCreditsProgramSource = creditsProgram.toString();
+        } finally {
+            creditsProgram.free();
+        }
+    }
+    return canonicalCreditsProgramSource;
+}
+
+function isCanonicalCreditsProgramSource(source: string | Program): boolean {
+    if (source instanceof Program) {
+        return source.toString() === getCanonicalCreditsProgramSource();
+    }
+
+    // API responses may format the same program differently (for example,
+    // numeric separators), so compare snarkVM's canonical serialization.
+    let parsed: Program | undefined;
+    try {
+        parsed = Program.fromString(source);
+        return parsed.toString() === getCanonicalCreditsProgramSource();
+    } catch {
+        return false;
+    } finally {
+        parsed?.free();
+    }
 }
 
 function preparedProcessHasCompatibleImport(
@@ -212,8 +243,10 @@ function preparedProcessHasCompatibleImport(
 ): boolean {
     // Every snarkVM process already contains credits.aleo, and the imports
     // builder intentionally does not retain that built-in in its metadata.
-    return name === CREDITS_PROGRAM_ID
-        || programs.get(name)?.programSource === normalizeProgramSource(source);
+    if (name === CREDITS_PROGRAM_ID) {
+        return isCanonicalCreditsProgramSource(source);
+    }
+    return programs.get(name)?.programSource === normalizeProgramSource(source);
 }
 
 function preparedProcessSupports(

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1539,6 +1539,38 @@ describe("ProgramImportsBuilder", () => {
             }
         });
 
+        it("should not refetch an explicitly requested sibling import", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const getProgramStub = sinon.stub(pm.networkClient, "getProgram");
+            getProgramStub.withArgs("multiply_test.aleo").resolves(ADD_PROGRAM);
+
+            const preparedProcess = await pm.prepareProcess({
+                programs: [
+                    {
+                        programName: "double_test.aleo",
+                        programSource: DOUBLE_PROGRAM,
+                        edition: 1,
+                    },
+                    {
+                        programName: "multiply_test.aleo",
+                        programSource: MULTIPLY_PROGRAM,
+                        edition: 1,
+                    },
+                ],
+            });
+
+            try {
+                expect(getProgramStub.called).to.equal(false);
+                expect(preparedProcess.supports({
+                    programName: "multiply_test.aleo",
+                    programSource: MULTIPLY_PROGRAM,
+                })).to.equal(true);
+            } finally {
+                preparedProcess.free();
+            }
+        });
+
         it("should serve import subsets and allow a preloaded import as an entry program", async () => {
             const keyProvider = createMockKeyProvider();
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1381,7 +1381,7 @@ describe("ProgramImportsBuilder", () => {
         });
     });
 
-    describe("Prepared programs", function () {
+    describe("Prepared contexts", function () {
         this.timeout(60_000);
 
         it("should reuse a prepared process for fee-master and direct-fee proving requests", async () => {
@@ -1475,6 +1475,144 @@ describe("ProgramImportsBuilder", () => {
             }
         });
 
+        it("should reuse one prepared process across programs and functions", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const privateKey = new PrivateKey();
+            const preparedProcess = await pm.prepareProcess({
+                programs: [
+                    {
+                        programName: "multi_fn_test.aleo",
+                        programSource: MULTI_FN_PROGRAM,
+                        edition: 1,
+                    },
+                    {
+                        programName: "sum_test.aleo",
+                        programSource: ADD_PROGRAM,
+                        edition: 1,
+                    },
+                ],
+            });
+
+            expect(preparedProcess.programNames).to.have.members([
+                "multi_fn_test.aleo",
+                "sum_test.aleo",
+            ]);
+            expect(preparedProcess.supports({
+                programName: "multi_fn_test.aleo",
+                functionName: "alpha",
+            })).to.equal(true);
+            expect(preparedProcess.supports({
+                programName: "multi_fn_test.aleo",
+                functionName: "beta",
+            })).to.equal(true);
+
+            try {
+                const calls = [
+                    {
+                        programName: "multi_fn_test.aleo",
+                        functionName: "alpha",
+                        inputs: ["5u32"],
+                    },
+                    {
+                        programName: "multi_fn_test.aleo",
+                        functionName: "beta",
+                        inputs: ["5u32"],
+                    },
+                    {
+                        programName: "sum_test.aleo",
+                        functionName: "sum_it",
+                        inputs: ["2u32", "3u32"],
+                    },
+                ];
+                for (const call of calls) {
+                    const authorization = await pm.buildAuthorizationUnchecked({
+                        ...call,
+                        privateKey,
+                        preparedProcess,
+                    });
+                    expect(authorization.transitions()).to.have.length(1);
+                    authorization.free();
+                }
+            } finally {
+                preparedProcess.free();
+            }
+        });
+
+        it("should serve import subsets and allow a preloaded import as an entry program", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const privateKey = new PrivateKey();
+
+            sinon.stub(pm.networkClient, "getProgramImports").resolves({
+                "multiply_test.aleo": MULTIPLY_PROGRAM,
+            });
+            sinon.stub(pm.networkClient, "getProgramAmendmentCount").callsFake(async (programName: string) => ({
+                program_id: programName,
+                edition: 1,
+                amendment_count: 0,
+            }));
+
+            const preparedProcess = await pm.prepareProcess({
+                programs: [{
+                    programName: "double_test.aleo",
+                    programSource: DOUBLE_PROGRAM,
+                    edition: 1,
+                }],
+                programImports: {
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                    "sum_test.aleo": ADD_PROGRAM,
+                },
+            });
+
+            expect(preparedProcess.programNames).to.have.members([
+                "double_test.aleo",
+                "multiply_test.aleo",
+                "sum_test.aleo",
+            ]);
+            expect(preparedProcess.supports({
+                programName: "double_test.aleo",
+                functionName: "double_it",
+                programImports: {
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                },
+            })).to.equal(true);
+            expect(preparedProcess.supports({
+                programName: "double_test.aleo",
+                functionName: "double_it",
+                programImports: {
+                    "multiply_test.aleo": ADD_PROGRAM,
+                },
+            })).to.equal(false);
+
+            try {
+                const doubleAuthorization = await pm.buildAuthorizationUnchecked({
+                    programName: "double_test.aleo",
+                    functionName: "double_it",
+                    inputs: ["5u32"],
+                    privateKey,
+                    programImports: {
+                        "multiply_test.aleo": MULTIPLY_PROGRAM,
+                    },
+                    preparedProcess,
+                });
+                expect(doubleAuthorization.transitions()).to.have.length(2);
+                doubleAuthorization.free();
+
+                const sumAuthorization = await pm.buildAuthorizationUnchecked({
+                    programName: "sum_test.aleo",
+                    functionName: "sum_it",
+                    inputs: ["2u32", "3u32"],
+                    privateKey,
+                    preparedProcess,
+                });
+                expect(sumAuthorization.transitions()).to.have.length(1);
+                sumAuthorization.free();
+            } finally {
+                preparedProcess.free();
+            }
+        });
+
         it("should use prepared imports when estimating a private fee record", async () => {
             const keyProvider = createMockKeyProvider();
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
@@ -1497,7 +1635,7 @@ describe("ProgramImportsBuilder", () => {
                 },
                 edition: 1,
             });
-            const estimateFeeStub = sinon.stub(pm, "estimateExecutionFee").resolves(1n);
+            const estimateFeeStub = sinon.stub(ProgramManagerBase, "estimateExecutionFee").returns(1n);
             sinon.stub(pm, "getCreditsRecord").resolves({} as any);
             sinon.stub(ProgramManagerBase, "buildProvingRequest").resolves({} as any);
 
@@ -1516,15 +1654,17 @@ describe("ProgramImportsBuilder", () => {
                 });
 
                 expect(estimateFeeStub.calledOnce).to.equal(true);
-                expect(estimateFeeStub.firstCall.args[0].imports).to.deep.equal({
-                    "multiply_test.aleo": MULTIPLY_PROGRAM,
-                });
+                expect(estimateFeeStub.firstCall.args[0]).to.equal(DOUBLE_PROGRAM);
+                expect(estimateFeeStub.firstCall.args[1]).to.equal("double_it");
+                expect(estimateFeeStub.firstCall.args[2]).to.equal(undefined);
+                expect(estimateFeeStub.firstCall.args[3]).to.equal(1);
+                expect(estimateFeeStub.firstCall.args[4]).to.be.instanceOf(ProgramImportsBuilder);
             } finally {
                 preparedProgram.free();
             }
         });
 
-        it("should materialize prepared imports exactly once per proving request", async () => {
+        it("should not materialize prepared imports during proving requests", async () => {
             const keyProvider = createMockKeyProvider();
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
 
@@ -1546,14 +1686,13 @@ describe("ProgramImportsBuilder", () => {
                 },
                 edition: 1,
             });
-            sinon.stub(pm, "estimateExecutionFee").resolves(1n);
+            sinon.stub(ProgramManagerBase, "estimateExecutionFee").returns(1n);
             sinon.stub(pm, "getCreditsRecord").resolves({} as any);
             sinon.stub(ProgramManagerBase, "buildProvingRequest").resolves({} as any);
 
-            // Copying import sources out of WASM dominates the prepared-path
-            // overhead in provingRequest. programImportsFromBuilder walks
-            // programNames once per materialization, so one call proves the
-            // import set crossed the WASM boundary exactly once.
+            // A prepared process is passed directly to both fee estimation and
+            // request building, so import source strings never cross back into
+            // JavaScript.
             const programNamesSpy = sinon.spy(
                 ProgramImportsBuilder.prototype,
                 "programNames",
@@ -1572,7 +1711,7 @@ describe("ProgramImportsBuilder", () => {
                     preparedProgram,
                 });
 
-                expect(programNamesSpy.callCount).to.equal(1);
+                expect(programNamesSpy.callCount).to.equal(0);
             } finally {
                 programNamesSpy.restore();
                 preparedProgram.free();
@@ -1729,6 +1868,88 @@ describe("ProgramImportsBuilder", () => {
             }
 
             expect(error?.message).to.equal("Prepared program has already been freed");
+        });
+
+        it("should fail clearly after a prepared process is freed", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const preparedProcess = await pm.prepareProcess({
+                programs: [{
+                    programName: "multiply_test.aleo",
+                    programSource: MULTIPLY_PROGRAM,
+                    edition: 1,
+                }],
+            });
+
+            preparedProcess.free();
+            preparedProcess.free();
+            expect(preparedProcess.supports({
+                programName: "multiply_test.aleo",
+                functionName: "multiply",
+            })).to.equal(false);
+
+            let error: Error | undefined;
+            try {
+                await pm.buildAuthorizationUnchecked({
+                    programName: "multiply_test.aleo",
+                    functionName: "multiply",
+                    inputs: ["2u32", "3u32"],
+                    privateKey: new PrivateKey(),
+                    preparedProcess,
+                });
+            } catch (e) {
+                error = e as Error;
+            }
+
+            expect(error?.message).to.equal("Prepared process has already been freed");
+        });
+
+        it("should reject concurrent use of one prepared context and release it afterwards", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const preparedProcess = await pm.prepareProcess({
+                programs: [{
+                    programName: "multiply_test.aleo",
+                    programSource: MULTIPLY_PROGRAM,
+                    edition: 1,
+                }],
+            });
+            const options = {
+                programName: "multiply_test.aleo",
+                functionName: "multiply",
+                inputs: ["2u32", "3u32"],
+                privateKey: new PrivateKey(),
+                preparedProcess,
+            };
+
+            let resolveFirst!: (value: unknown) => void;
+            const firstResult = new Promise((resolve) => {
+                resolveFirst = resolve;
+            });
+            const authorizationStub = sinon.stub(ProgramManagerBase, "buildAuthorizationUnchecked");
+            authorizationStub.onFirstCall().returns(firstResult as any);
+            authorizationStub.onSecondCall().resolves({} as any);
+
+            try {
+                const firstCall = pm.buildAuthorizationUnchecked(options);
+
+                let error: Error | undefined;
+                try {
+                    await pm.buildAuthorizationUnchecked(options);
+                } catch (e) {
+                    error = e as Error;
+                }
+                expect(error?.message).to.equal(
+                    "Prepared context is already in use; calls sharing a prepared context must be sequential",
+                );
+
+                resolveFirst({});
+                await firstCall;
+                await pm.buildAuthorizationUnchecked(options);
+                expect(authorizationStub.callCount).to.equal(2);
+            } finally {
+                preparedProcess.free();
+            }
         });
     });
 

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -2040,6 +2040,7 @@ describe("ProgramImportsBuilder", () => {
             });
             sinon.stub(ProgramManagerBase, "buildAuthorizationUnchecked").resolves({} as any);
             const getProgramSpy = sinon.spy(ProgramImportsBuilder.prototype, "getProgram");
+            const isEmptySpy = sinon.spy(ProgramImportsBuilder.prototype, "isEmpty");
             const cloneSpy = sinon.spy(ProgramImportsBuilder.prototype, "clone");
 
             try {
@@ -2076,9 +2077,11 @@ describe("ProgramImportsBuilder", () => {
                 // Import validation is answered from JavaScript-side metadata, so
                 // the only WASM handle created is the one handed to the call itself.
                 expect(getProgramSpy.callCount).to.equal(0);
+                expect(isEmptySpy.callCount).to.equal(0);
                 expect(cloneSpy.callCount).to.equal(1);
             } finally {
                 getProgramSpy.restore();
+                isEmptySpy.restore();
                 cloneSpy.restore();
                 preparedProgram.free();
             }

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1571,6 +1571,46 @@ describe("ProgramImportsBuilder", () => {
             }
         });
 
+        it("should accept the built-in credits program when it is absent from process metadata", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const privateKey = new PrivateKey();
+            const creditsProgram = Program.getCreditsProgram();
+            const creditsSource = creditsProgram.toString();
+            creditsProgram.free();
+
+            const preparedProcess = await pm.prepareProcess({
+                programs: [{
+                    programName: "multiply_test.aleo",
+                    programSource: MULTIPLY_PROGRAM,
+                    edition: 1,
+                }],
+            });
+            const call = {
+                programName: "multiply_test.aleo",
+                functionName: "multiply",
+                programImports: {
+                    "credits.aleo": creditsSource,
+                },
+            };
+
+            expect(preparedProcess.programNames).not.to.include("credits.aleo");
+            expect(preparedProcess.supports(call)).to.equal(true);
+
+            try {
+                const authorization = await pm.buildAuthorizationUnchecked({
+                    ...call,
+                    inputs: ["2u32", "3u32"],
+                    privateKey,
+                    preparedProcess,
+                });
+                expect(authorization.transitions()).to.have.length(1);
+                authorization.free();
+            } finally {
+                preparedProcess.free();
+            }
+        });
+
         it("should serve import subsets and allow a preloaded import as an entry program", async () => {
             const keyProvider = createMockKeyProvider();
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1576,7 +1576,9 @@ describe("ProgramImportsBuilder", () => {
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
             const privateKey = new PrivateKey();
             const creditsProgram = Program.getCreditsProgram();
-            const creditsSource = creditsProgram.toString();
+            // Network responses may contain non-canonical whitespace even
+            // though they parse to the canonical built-in program.
+            const creditsSource = `\n${creditsProgram.toString()}\n`;
             creditsProgram.free();
 
             const preparedProcess = await pm.prepareProcess({
@@ -1596,6 +1598,12 @@ describe("ProgramImportsBuilder", () => {
 
             expect(preparedProcess.programNames).not.to.include("credits.aleo");
             expect(preparedProcess.supports(call)).to.equal(true);
+            expect(preparedProcess.supports({
+                ...call,
+                programImports: {
+                    "credits.aleo": MULTIPLY_PROGRAM,
+                },
+            })).to.equal(false);
 
             try {
                 const authorization = await pm.buildAuthorizationUnchecked({
@@ -1606,6 +1614,24 @@ describe("ProgramImportsBuilder", () => {
                 });
                 expect(authorization.transitions()).to.have.length(1);
                 authorization.free();
+
+                let error: Error | undefined;
+                try {
+                    await pm.buildAuthorizationUnchecked({
+                        ...call,
+                        inputs: ["2u32", "3u32"],
+                        privateKey,
+                        programImports: {
+                            "credits.aleo": MULTIPLY_PROGRAM,
+                        },
+                        preparedProcess,
+                    });
+                } catch (e) {
+                    error = e as Error;
+                }
+                expect(error?.message).to.equal(
+                    "Prepared process import 'credits.aleo' does not match a loaded program",
+                );
             } finally {
                 preparedProcess.free();
             }

--- a/sdk/tests/program-imports.test.ts
+++ b/sdk/tests/program-imports.test.ts
@@ -1936,7 +1936,7 @@ describe("ProgramImportsBuilder", () => {
             expect(error?.message).to.equal("Prepared process has already been freed");
         });
 
-        it("should reject concurrent use of one prepared context and release it afterwards", async () => {
+        it("should serialize concurrent WASM access to one prepared context instead of rejecting", async () => {
             const keyProvider = createMockKeyProvider();
             const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
             const preparedProcess = await pm.prepareProcess({
@@ -1960,27 +1960,127 @@ describe("ProgramImportsBuilder", () => {
             });
             const authorizationStub = sinon.stub(ProgramManagerBase, "buildAuthorizationUnchecked");
             authorizationStub.onFirstCall().returns(firstResult as any);
-            authorizationStub.onSecondCall().resolves({} as any);
+            authorizationStub.onSecondCall().resolves({ order: "second" } as any);
+            authorizationStub.onThirdCall().resolves({ order: "third" } as any);
 
             try {
                 const firstCall = pm.buildAuthorizationUnchecked(options);
+                const secondCall = pm.buildAuthorizationUnchecked(options);
+                const thirdCall = pm.buildAuthorizationUnchecked(options);
+
+                // Let all three calls progress up to the WASM boundary. Only the
+                // first may enter WASM while it is still pending; the others are
+                // queued behind it rather than rejected.
+                await new Promise((resolve) => setTimeout(resolve, 20));
+                expect(authorizationStub.callCount).to.equal(1);
+
+                resolveFirst({ order: "first" });
+                const results = await Promise.all([firstCall, secondCall, thirdCall]);
+                expect(results.map((result: any) => result.order)).to.deep.equal([
+                    "first",
+                    "second",
+                    "third",
+                ]);
+                expect(authorizationStub.callCount).to.equal(3);
+            } finally {
+                preparedProcess.free();
+            }
+        });
+
+        it("should keep serving a prepared context after a queued call fails", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            const preparedProcess = await pm.prepareProcess({
+                programs: [{
+                    programName: "multiply_test.aleo",
+                    programSource: MULTIPLY_PROGRAM,
+                    edition: 1,
+                }],
+            });
+            const options = {
+                programName: "multiply_test.aleo",
+                functionName: "multiply",
+                inputs: ["2u32", "3u32"],
+                privateKey: new PrivateKey(),
+                preparedProcess,
+            };
+
+            const authorizationStub = sinon.stub(ProgramManagerBase, "buildAuthorizationUnchecked");
+            authorizationStub.onFirstCall().rejects(new Error("wasm failure"));
+            authorizationStub.onSecondCall().resolves({} as any);
+
+            try {
+                const [failed, succeeded] = await Promise.allSettled([
+                    pm.buildAuthorizationUnchecked(options),
+                    pm.buildAuthorizationUnchecked(options),
+                ]);
+                expect(failed.status).to.equal("rejected");
+                expect((failed as PromiseRejectedResult).reason.message).to.equal("wasm failure");
+                expect(succeeded.status).to.equal("fulfilled");
+                expect(authorizationStub.callCount).to.equal(2);
+            } finally {
+                preparedProcess.free();
+            }
+        });
+
+        it("should not touch WASM while validating prepared program imports", async () => {
+            const keyProvider = createMockKeyProvider();
+            const pm = new ProgramManager("https://api.provable.com/v2", keyProvider);
+            sinon.stub(pm.networkClient, "getProgramImports").resolves({
+                "multiply_test.aleo": MULTIPLY_PROGRAM,
+            });
+            const preparedProgram = await pm.prepareProgram({
+                programName: "double_test.aleo",
+                functionName: "double_it",
+                programSource: DOUBLE_PROGRAM,
+                programImports: {
+                    "multiply_test.aleo": MULTIPLY_PROGRAM,
+                },
+                edition: 1,
+            });
+            sinon.stub(ProgramManagerBase, "buildAuthorizationUnchecked").resolves({} as any);
+            const getProgramSpy = sinon.spy(ProgramImportsBuilder.prototype, "getProgram");
+            const cloneSpy = sinon.spy(ProgramImportsBuilder.prototype, "clone");
+
+            try {
+                await pm.buildAuthorizationUnchecked({
+                    programName: "double_test.aleo",
+                    functionName: "double_it",
+                    inputs: ["5u32"],
+                    privateKey: new PrivateKey(),
+                    programImports: {
+                        "multiply_test.aleo": MULTIPLY_PROGRAM,
+                    },
+                    preparedProgram,
+                });
 
                 let error: Error | undefined;
                 try {
-                    await pm.buildAuthorizationUnchecked(options);
+                    await pm.buildAuthorizationUnchecked({
+                        programName: "double_test.aleo",
+                        functionName: "double_it",
+                        inputs: ["5u32"],
+                        privateKey: new PrivateKey(),
+                        programImports: {
+                            "multiply_test.aleo": ADD_PROGRAM,
+                        },
+                        preparedProgram,
+                    });
                 } catch (e) {
                     error = e as Error;
                 }
                 expect(error?.message).to.equal(
-                    "Prepared context is already in use; calls sharing a prepared context must be sequential",
+                    "Prepared program import 'multiply_test.aleo' does not match the supplied import",
                 );
 
-                resolveFirst({});
-                await firstCall;
-                await pm.buildAuthorizationUnchecked(options);
-                expect(authorizationStub.callCount).to.equal(2);
+                // Import validation is answered from JavaScript-side metadata, so
+                // the only WASM handle created is the one handed to the call itself.
+                expect(getProgramSpy.callCount).to.equal(0);
+                expect(cloneSpy.callCount).to.equal(1);
             } finally {
-                preparedProcess.free();
+                getProgramSpy.restore();
+                cloneSpy.restore();
+                preparedProgram.free();
             }
         });
     });

--- a/wasm/src/programs/manager/proving_request.rs
+++ b/wasm/src/programs/manager/proving_request.rs
@@ -29,6 +29,8 @@ use crate::{
 };
 
 use js_sys::{Array, Object};
+use snarkvm_console::network::ConsensusVersion;
+use snarkvm_synthesizer::prelude::execution_cost_for_authorization;
 use std::str::FromStr;
 
 fn requires_fee_authorization(program_id: &str, function_name: &str, use_fee_master: bool) -> bool {
@@ -74,7 +76,7 @@ impl ProgramManager {
         log(&format!("Creating proving request for {function_name}"));
         let edition = edition.unwrap_or(1);
 
-        let mut resolved = ResolvedProcess::resolve(&program_imports, program, edition, imports.clone())?;
+        let mut resolved = ResolvedProcess::resolve(&program_imports, program, edition, imports)?;
         let should_authorize_fee =
             requires_fee_authorization(&resolved.program().id().to_string(), function_name, use_fee_master);
         let process = resolved.process_mut();
@@ -94,18 +96,12 @@ impl ProgramManager {
 
         let fee_authorization = if should_authorize_fee {
             // Estimate the base fee only when this request will include a fee
-            // authorization. Fee-master requests omit it entirely.
-            //
-            // We intentionally pass None for program_imports here to avoid a
-            // RefCell double-borrow panic. The inner guard still holds a mutable
-            // borrow on the builder, so the legacy imports Object path is used.
-            let base_fee_microcredits = ProgramManager::estimate_fee_for_authorization(
-                &crate::Authorization::from(&authorization),
-                program,
-                imports,
-                Some(edition),
-                None,
-            )?;
+            // authorization. Reuse the already-resolved process directly so a
+            // prepared context never needs to copy all import sources through
+            // JavaScript and build a second process for fee estimation.
+            let (base_fee_microcredits, _) =
+                execution_cost_for_authorization(process, &authorization, ConsensusVersion::latest())
+                    .map_err(|e| e.to_string())?;
             let execution_id = authorization.to_execution_id().map_err(|e| e.to_string())?;
 
             Some(authorize_fee!(


### PR DESCRIPTION
## Motivation

`ProgramManager.prepareProgram` introduced reusable snarkVM contexts scoped to a single program and function. Long-lived consumers such as wallets frequently authorize several functions across the same stable program graph. Creating a separate process for every program/function pair duplicates initialization work and memory.

Dynamic-dispatch consumers may also know the complete set of possible target programs ahead of time, while each individual invocation only uses a subset of that set.

## Changes

- Add `ProgramManager.prepareProcess()` and `PreparedProcess`.
- Allow one prepared snarkVM process to contain multiple programs and serve any function from any loaded program.
- Resolve program sources, editions, static imports, and transitive dependencies once during preparation.
- Allow callers to preload a superset of dynamic-dispatch programs and later use matching import subsets.
- Add `PreparedProcess.supports()` and expose loaded program metadata for compatibility checks.
- Validate supplied sources, editions, functions, and imports before reusing a process.
- Preserve the existing function-scoped `PreparedProgram` API for backwards compatibility.
- Reject concurrent use of the same prepared context with a catchable error instead of allowing a WASM `RefCell` borrow panic.
- Reuse the already-resolved process for fee calculation, avoiding import-source materialization through JavaScript and construction of a second process.

Consumers requiring concurrent authorizations can maintain multiple independent prepared processes, while each process can still cover a broad program and function set.

## Example

```ts
const prepared = await programManager.prepareProcess({
    programs: [
        { programName: "wallet_router.aleo" },
        { programName: "token_registry.aleo" },
    ],
    programImports: dynamicDispatchPrograms,
});

try {
    const authorization = await programManager.buildAuthorizationUnchecked({
        programName: "wallet_router.aleo",
        functionName: "transfer",
        inputs,
        preparedProcess: prepared,
    });
} finally {
    prepared.free();
}
```

## Testing

- Added coverage for multiple functions within one process.
- Added coverage for multiple independent entry programs.
- Added coverage for dynamic-dispatch supersets and invocation subsets.
- Added lifecycle and concurrent-use coverage.
- Added coverage ensuring prepared imports are not materialized into JavaScript during proving requests.
- Verified SDK build and Rust compilation for mainnet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core authorization, proving, and fee-estimation paths plus WASM concurrency semantics; behavior changes for prepared-context reuse and fee calculation, though existing single-function `PreparedProgram` usage remains supported.
> 
> **Overview**
> Adds **`ProgramManager.prepareProcess()`** and **`PreparedProcess`**, so one snarkVM process can be warmed once with multiple programs (and optional dynamic-dispatch import supersets) and then drive **`buildAuthorization`**, **`buildAuthorizationUnchecked`**, and **`provingRequest`** via a new **`preparedProcess`** option alongside existing **`PreparedProgram`**.
> 
> Preparation resolves sources, editions, static/transitive imports once (including topological load order and avoiding refetch of sibling programs), exposes **`supports()`** and per-program metadata for compatibility checks, and validates imports from JS snapshots—including canonical **`credits.aleo`**—without borrowing WASM during validation.
> 
> Shared prepared contexts now **queue concurrent WASM work** through **`withPreparedContextWasm`** instead of risking RefCell panics. Private-fee **`provingRequest`** paths call **`WasmProgramManager.estimateExecutionFee`** with the process builder directly; Rust **`build_proving_request`** estimates fees via **`execution_cost_for_authorization`** on the already-resolved process, dropping the second-process / JS import-materialization path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3869bf2e64115795df90f148b9805bf42ecf976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->